### PR TITLE
Update image download section with coreos changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,17 +183,15 @@
       <div class="col-12 col-md-4 col-lg-4 col-xl-4">
         <div class="serverbox">
           <img src="img/icons2.png" />
-          <h4>CoreOS Container Linux</h4>
-          <p>From <a href="https://coreos.com/releases/" target="_blank"  class="linkbox">coreos.com/releases</a></p>
+          <h4>Fedora CoreOS</h4>
+          <p>From <a href="https://getfedora.org/en/coreos/download/" target="_blank"  class="linkbox">getfedora.org/en/coreos</a></p>
         </div>
       </div>
       <div class="col-12 col-md-8 col-lg-8 col-xl-8">
         <div class="serverbox">
           <img src="img/icons3.png" />
-          <h4>Fedora and Fedora Atomic Host</h4>
-          <ul>
-            <li> Fedora from <br /><a href="https://alt.fedoraproject.org/cloud/" target="_blank"  class="linkbox"> alt.fedoraproject.org/cloud </a></li>
-            <li>Fedora Atomic Host from <br /> <a href="https://getfedora.org/en/atomic/download/" target="_blank" class="linkbox"> getfedora.org/en/atomic/download</a></li>
+          <h4>Fedora</h4>
+          <p>From <a href="https://alt.fedoraproject.org/cloud/" target="_blank"  class="linkbox"> alt.fedoraproject.org/cloud </a></p>
           </ul>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -262,7 +262,7 @@
 
 <!-- footer start here -->
 <section class="copyright">
-  Copyright © 2018 AppScale Systems. All rights reserved.
+  Copyright © 2018-2020 AppScale Systems. All rights reserved.
 </section>
 <!-- footer end here -->
 


### PR DESCRIPTION
Update image download section to remove fedora atomic (broken link) and switch from coreos to fedora coreos.